### PR TITLE
[BUG修复]修复#2、改进异常处理

### DIFF
--- a/app/src/main/java/team/one/lwe/network/NetworkThread.java
+++ b/app/src/main/java/team/one/lwe/network/NetworkThread.java
@@ -6,6 +6,7 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 
 import cn.hutool.core.io.IORuntimeException;
+import cn.hutool.http.HttpException;
 import team.one.lwe.bean.ASResponse;
 
 public abstract class NetworkThread extends Thread {
@@ -47,6 +48,12 @@ public abstract class NetworkThread extends Thread {
                 }
                 else {
                     onException(e);
+                }
+            });
+        } catch (HttpException e) {
+            view.post(() -> {
+                if ("Connection reset".equals(e.getMessage())) {
+                    onFailed(415, "connection failed");
                 }
             });
         }

--- a/app/src/main/java/team/one/lwe/network/NetworkThread.java
+++ b/app/src/main/java/team/one/lwe/network/NetworkThread.java
@@ -1,5 +1,6 @@
 package team.one.lwe.network;
 
+import android.util.Log;
 import android.view.View;
 
 import java.net.ConnectException;
@@ -23,7 +24,9 @@ public abstract class NetworkThread extends Thread {
 
     public abstract void onFailed(int code, String desc);
 
-    public abstract void onException(IORuntimeException e);
+    public void onException(Exception e) {
+        Log.e(view.getTransitionName(), Log.getStackTraceString(e));
+    }
 
     @Override
     public void run() {
@@ -55,7 +58,12 @@ public abstract class NetworkThread extends Thread {
                 if ("Connection reset".equals(e.getMessage())) {
                     onFailed(415, "connection failed");
                 }
+                else {
+                    onException(e);
+                }
             });
+        } catch (Exception e) {
+            view.post(() -> onException(e));
         }
     }
 }

--- a/app/src/main/java/team/one/lwe/network/NetworkThread.java
+++ b/app/src/main/java/team/one/lwe/network/NetworkThread.java
@@ -43,7 +43,7 @@ public abstract class NetworkThread extends Thread {
             });
         } catch (IORuntimeException e) {
             view.post(() -> {
-                if (e.causeInstanceOf(ConnectException.class)) {
+                if (e.causeInstanceOf(ConnectException.class) && e.getMessage().contains("Failed to connect to")) { //connection refused
                     onFailed(415, "connection failed");
                 }
                 else if (e.causeInstanceOf(SocketTimeoutException.class)) {
@@ -55,7 +55,7 @@ public abstract class NetworkThread extends Thread {
             });
         } catch (HttpException e) {
             view.post(() -> {
-                if ("Connection reset".equals(e.getMessage())) {
+                if ("Connection reset".equals(e.getMessage())) { //connection reset
                     onFailed(415, "connection failed");
                 }
                 else {

--- a/app/src/main/java/team/one/lwe/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/team/one/lwe/ui/fragment/LoginFragment.java
@@ -92,11 +92,6 @@ public class LoginFragment extends Fragment {
                     }
                 }
             }
-
-            @Override
-            public void onException(IORuntimeException e) {
-                e.printStackTrace();
-            }
         }.start();
     }
 

--- a/app/src/main/java/team/one/lwe/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/team/one/lwe/ui/fragment/LoginFragment.java
@@ -19,7 +19,6 @@ import com.netease.nimlib.sdk.RequestCallback;
 import com.netease.nimlib.sdk.auth.LoginInfo;
 import org.jetbrains.annotations.NotNull;
 
-import cn.hutool.core.io.IORuntimeException;
 import team.one.lwe.R;
 import team.one.lwe.bean.ASResponse;
 import team.one.lwe.network.NetworkThread;
@@ -91,6 +90,12 @@ public class LoginFragment extends Fragment {
                         ToastHelper.showToast(view.getContext(), R.string.lwe_error_unknown);
                     }
                 }
+            }
+
+            @Override
+            public void onException(Exception e) {
+                DialogMaker.dismissProgressDialog();
+                super.onException(e);
             }
         }.start();
     }


### PR DESCRIPTION
**所修复的Bug**
#2 

**原因分析**
https://github.com/misterplus/LearnWithEase/blob/f8894d678422182f00c6ebd81225b2e45a875622/app/src/main/java/team/one/lwe/network/NetworkThread.java#L40-L52
此处代码只catch了IORuntimeException
https://github.com/misterplus/LearnWithEase/blob/f8894d678422182f00c6ebd81225b2e45a875622/app/src/main/java/team/one/lwe/ui/fragment/LoginFragment.java#L48
但此处若服务器不在线，还有可能抛出HttpException: Connection reset
**修复思路**
https://github.com/misterplus/LearnWithEase/pull/6/commits/397a84c1fe9234b54ace8040eee855f0d17fadaa
添加对应catch分支

**附带优化**
https://github.com/misterplus/LearnWithEase/pull/6/commits/a868f2a78fcee4148c8d87fd9c3128e8c7f49124
为NetworkThread:onException提供了默认实现，添加了catch所有异常的分支。